### PR TITLE
Update TTGTagCollectionView.m

### DIFF
--- a/TTGTagCollectionView/Classes/TTGTagCollectionView.m
+++ b/TTGTagCollectionView/Classes/TTGTagCollectionView.m
@@ -351,8 +351,8 @@
                 currentLineWidth = maxLineWidth;
                 
                 if (_alignment == TTGTagCollectionAlignmentFillByExpandingWidthExceptLastLine &&
-                    currentLine == numberOfLines - 1 &&
-                    numberOfLines != 1) {
+                    currentLine == numberOfLines - 1 /*&&
+                    numberOfLines != 1*/) {
                     // Reset last line width for TTGTagCollectionAlignmentFillByExpandingWidthExceptLastLine
                     currentLineAdditionWidth = 0;
                 }


### PR DESCRIPTION
TTGTagCollectionAlignmentFillByExpandingWidthExceptLastLine模式下，只有一行的时候，防止item填充满整行